### PR TITLE
Set build type based on $ROS_VERSION

### DIFF
--- a/scxml_core/package.xml
+++ b/scxml_core/package.xml
@@ -7,11 +7,7 @@
   <maintainer email="jrgnichodevel@gmail.com">Jorge Nicho</maintainer>
   <license>BSD3</license>
 
-  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
-  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
-
   <export>
-    <build_type condition="$ROS_VERSION == 1">catkin</build_type>
-    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
+    <build_type> cmake </build_type>
   </export>
 </package>

--- a/scxml_core/package.xml
+++ b/scxml_core/package.xml
@@ -7,8 +7,11 @@
   <maintainer email="jrgnichodevel@gmail.com">Jorge Nicho</maintainer>
   <license>BSD3</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
+
   <export>
-    <build_type>cmake</build_type>  
+    <build_type condition="$ROS_VERSION == 1">catkin</build_type>
+    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
   </export>
 </package>


### PR DESCRIPTION
This fixes this error when running rosdep in ROS2
```
scxml_core: Cannot locate rosdep definition for [catkin]
```