### PR TITLE
Set build type based on $ROS_VERSION

### DIFF
--- a/scxml_core/package.xml
+++ b/scxml_core/package.xml
@@ -7,8 +7,7 @@
   <maintainer email="jrgnichodevel@gmail.com">Jorge Nicho</maintainer>
   <license>BSD3</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
   <export>
-    <build_type>cmake</build_type>  
+    <build_type> cmake </build_type>
   </export>
 </package>


### PR DESCRIPTION
Actually this should work since the names are different for this package. I couldn't reopen the PR since I force pushed, but this will allow building on ROS1/ROS2 without any mixins or modifications.

Building ROS 1 with catkin tools it ignores rclcpp_scxml_demos because ament is not a supported build type.

Building ROS2 with colcon it ignores roscpp_scxml_demos because of the colcon_ignore.