### PR TITLE
Build improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ jobs:
       - CLANG_FORMAT_VERSION=8
       - AFTER_SCRIPT=""
       - BADGE=clang-format
+      - ROSDEP_SKIP_KEYS="catkin roscpp"
       cache:
         directories:
           - $HOME/.ccache
@@ -44,6 +45,7 @@ jobs:
       - NOT_TEST_BUILD=true
       - BEFORE_INIT="apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654"
       - BADGE=eloquent
+      - ROSDEP_SKIP_KEYS="catkin roscpp"
       cache:
         directories:
           - $HOME/.ccache

--- a/README.md
+++ b/README.md
@@ -72,48 +72,17 @@ The `demo_scxml_state_machine` ROS node shows how to use the State Machine libra
 ---
 ### Workspace Setup
 #### catkin (ROS1)
-1. Blacklist ros2 package, from the repo directory run the following:
-    ```
-    cat catkin-ignore.txt | xargs -n 1 catkin config -a --blacklist
-    ```
 
-2. Build the workspace
+1. Build the workspace
     ```
     catkin build
     ```
 
-#### colcon (ROS2)
-These steps use the [mixin feature of colcon](https://github.com/colcon/colcon-mixin-repository) to ignore ros1 (catkin) packages. More on that [here](https://colcon.readthedocs.io/en/released/reference/verb/mixin.html)
-1. Create a *mixin* directory in your workspace directory
-	```
-	mkdir mixin
-	```
-2. Create an **index.yaml** file with the following content
-	```
-	mixin:
-    - skip.mixin
-    ```
-    
-3. Copy the **skip.mixin** file of the repo into the mixin directory
-	```
-	cp src/ros_scxml/skip.mixin mixin
-	```
-	
-4. Add the mixin to the colcon workspace
-	```
-	colcon mixin add skip file://`pwd`/mixin/index.yaml
-	colcon mixin update skip
-	```
-		
-	NOTE: If you need to blacklist other packages then edit the **mixin/skip.mixin** file and add those
-	packages to the `packages-skip` list
-	
-5. Build colcon environment
-	```
-	colcon build --symlink-install --mixin skip
-	```
-
-> These instructions were inspired by this [ros answers post](https://answers.ros.org/question/306624/ignore-package-in-colcon-but-not-catkin/)
+#### colcon (ROS2)	
+1. Build colcon environment
+	  ```
+	  colcon build --symlink-install
+	  ```
 ---
 ### RUN Demo
 #### ROS 1

--- a/catkin-ignore.txt
+++ b/catkin-ignore.txt
@@ -1,1 +1,0 @@
-rclcpp_scxml_demos

--- a/rclcpp_scxml_demos/CMakeLists.txt
+++ b/rclcpp_scxml_demos/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.5)
 project(rclcpp_scxml_demos)
 
+if (NOT $ENV{ROS_VERSION} EQUAL "2")
+  message(WARNING "ROS Version $ENV{ROS_VERSION} found, skipping project ${PROJECT_NAME}")
+  return()
+endif()
+
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)

--- a/roscpp_scxml_demos/CMakeLists.txt
+++ b/roscpp_scxml_demos/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.1.0)
 project(roscpp_scxml_demos)
 
+if (NOT $ENV{ROS_VERSION} EQUAL "1")
+  message(WARNING "ROS Version $ENV{ROS_VERSION} found, skipping project ${PROJECT_NAME}")
+  return()
+endif()
+
 ## Compile as C++14, supported in ROS Kinetic and newer
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/skip.mixin
+++ b/skip.mixin
@@ -1,8 +1,0 @@
-{
-  "build": {
-    "skip": {
-      "packages-skip": ["roscpp_scxml_demos"
-                        ],
-    }
-  }
-}


### PR DESCRIPTION
This PR checks for the ROS version in the cmake and skips the build whenever the incorrect version is found.  These changes eliminate the need to use mikin (in colcon for ROS2) and blacklisting (in catkin for ROS1)