### PR TITLE
Feature return shared future result

### DIFF
--- a/rclcpp_scxml_demos/src/demo_scxml_sm.cpp
+++ b/rclcpp_scxml_demos/src/demo_scxml_sm.cpp
@@ -63,7 +63,7 @@ public:
     // prompts the sm to execute an action.
     execute_state_subs_ = node_->create_subscription<std_msgs::msg::String>(
         EXECUTE_ACTION_TOPIC, 1, [this](const std_msgs::msg::String::SharedPtr msg) {
-          std::cout<< "\n>>>>>>>>>>>> Got new action message <<<<<<<<<<<<<" << std::endl;
+          std::cout << "\n>>>>>>>>>>>> Got new action message <<<<<<<<<<<<<" << std::endl;
           if (sm_->isBusy())
           {
             RCLCPP_ERROR(node_->get_logger(), "State Machine is busy");
@@ -72,7 +72,7 @@ public:
 
           rclcpp::Clock ros_clock;
           std::shared_future<Response> res_fut = sm_->execute(Action{ .id = msg->data, .data = ros_clock.now() });
-          if(res_fut.wait_for(std::chrono::seconds(5)) != std::future_status::ready)
+          if (res_fut.wait_for(std::chrono::seconds(5)) != std::future_status::ready)
           {
             RCLCPP_INFO(node_->get_logger(), "Took too long to get response");
             return;
@@ -281,7 +281,7 @@ int main(int argc, char** argv)
             // queuing action, should exit the state
             sm->postAction(Action{ .id = "trIdle" });
             RCLCPP_INFO(node->get_logger(), "Posted trIdle action");
-            return Response(true,22.0);
+            return Response(true, 22.0);
           },
           false);  // false = runs sequentially, use for non-blocking functions
     },

--- a/roscpp_scxml_demos/src/demo_scxml_sm.cpp
+++ b/roscpp_scxml_demos/src/demo_scxml_sm.cpp
@@ -269,7 +269,7 @@ int main(int argc, char** argv)
             ros::Duration(3.0).sleep();
             // queuing action, should exit the state
             sm->postAction(Action{ .id = "trIdle" });
-            return true;
+            return Response(true, 22.0);
           },
           false);  // false = runs sequentially, use for non-blocking functions
     },

--- a/roscpp_scxml_demos/src/demo_scxml_sm.cpp
+++ b/roscpp_scxml_demos/src/demo_scxml_sm.cpp
@@ -74,7 +74,15 @@ public:
             return;
           }
 
-          Response res = sm_->execute(Action{ .id = msg->data, .data = ros::Time::now().toSec() });
+          std::shared_future<Response> res_fut =
+              sm_->execute(Action{ .id = msg->data, .data = ros::Time::now().toSec() });
+          if (res_fut.wait_for(std::chrono::seconds(5)) != std::future_status::ready)
+          {
+            ROS_INFO("Took too long to get response");
+            return;
+          }
+
+          Response res = res_fut.get();
           if (!res)
           {
             return;

--- a/scxml_core/include/scxml_core/state_machine.h
+++ b/scxml_core/include/scxml_core/state_machine.h
@@ -132,8 +132,8 @@ private:
     EntryCallback cb_;
     QThreadPool* tpool_;
     QFutureWatcher<Response>* fut_watcher_ = new QFutureWatcher<Response>();
-    QFuture<Response>* qfuture = nullptr;
-    std::shared_ptr<std::promise<Response>> promise_res = std::make_shared<std::promise<Response>>();
+    QFuture<Response>* qfuture_ = nullptr;
+    std::shared_ptr<std::promise<Response>> promise_res_ = std::make_shared<std::promise<Response>>();
   };
   typedef std::shared_ptr<EntryCbHandler> EntryCbHandlerPtr;
 
@@ -250,10 +250,10 @@ protected:
 
   std::shared_future<Action> action_future_;
   using ResponseFuturesMap = std::map<int, std::shared_future<Response>>;
-  std::promise< ResponseFuturesMap > responses_map_promise_;
+  std::promise<ResponseFuturesMap> responses_map_promise_;
   std::map<std::string, PreconditionCallback> precond_callbacks_;
   std::map<std::string, EntryCbHandlerPtr> entry_callbacks_;
-  std::map<std::string, std::function<void()> > exit_callbacks_;
+  std::map<std::string, std::function<void()>> exit_callbacks_;
   QThreadPool* async_thread_pool_;
   mutable std::mutex entered_states_mutex_;
   std::deque<QScxmlStateMachineInfo::StateId> entered_states_queue_;

--- a/scxml_core/include/scxml_core/state_machine.h
+++ b/scxml_core/include/scxml_core/state_machine.h
@@ -45,7 +45,6 @@
 #include <private/qscxmlstatemachineinfo_p.h>
 #include <private/qscxmlstatemachine_p.h>
 #include <QTimer>
-#include <QFutureWatcher>
 #include <QThread>
 #include <QThreadPool>
 #include <QtConcurrent/QtConcurrent>
@@ -131,8 +130,6 @@ private:
     bool async_execution_;
     EntryCallback cb_;
     QThreadPool* tpool_;
-    QFutureWatcher<Response>* fut_watcher_ = new QFutureWatcher<Response>();
-    QFuture<Response>* qfuture_ = nullptr;
     std::shared_ptr<std::promise<Response>> promise_res_ = std::make_shared<std::promise<Response>>();
   };
   typedef std::shared_ptr<EntryCbHandler> EntryCbHandlerPtr;

--- a/scxml_core/include/scxml_core/state_machine.h
+++ b/scxml_core/include/scxml_core/state_machine.h
@@ -114,8 +114,8 @@ private:
   class EntryCbHandler
   {
   public:
-    EntryCbHandler(QThreadPool* thread_pool, EntryCallback cb, bool async_execution = false)
-      : cb_(cb), async_execution_(async_execution), tpool_(thread_pool)
+    EntryCbHandler(QThreadPool* thread_pool, EntryCallback cb, bool discard_response = false)
+      : cb_(cb), discard_response_(discard_response), tpool_(thread_pool)
     {
     }
 
@@ -127,7 +127,7 @@ private:
     std::shared_future<Response> operator()(const Action& arg);
 
   private:
-    bool async_execution_;
+    bool discard_response_;
     EntryCallback cb_;
     QThreadPool* tpool_;
     std::shared_ptr<std::promise<Response>> promise_res_ = std::make_shared<std::promise<Response>>();
@@ -166,21 +166,20 @@ public:
    * When the callback returns a valid result then the transition proceeds, otherwise the transition is
    * negated.
    * @param st_name The name of the state
-   * @param cb      The callback to be invoked; it must be a non-blocking function.
+   * @param cb      The callback to be invoked; long running blocking functions are not recommended.
    * @return  True on success, false otherwise
    */
   bool addPreconditionCallback(const std::string& st_name, PreconditionCallback cb);
 
   /**
-   * @brief adds a callback that gets invoked when a state is entered
-   * @param st_name         The name of the state
-   * @param cb              The callback to be invoked; it can be a blocking function.
-   * @param async_execution The callback will be executed asynchronously however the result returned by the
-   *                        callback won't be forwarded by the < b>execute()< /b> method back to the client
-   *                         code.
+   * @brief adds a callback that gets invoked asynchronously when a state is entered
+   * @param st_name           The name of the state
+   * @param cb                The callback to be invoked; it can be a blocking function.
+   * @param discard_response  When true the callback will be executed asynchronously however the Response returned by
+   * the callback won't be forwarded by the < b>execute()< /b> method back to the client code.
    * @return  True on success, false otherwise
    */
-  bool addEntryCallback(const std::string& st_name, EntryCallback cb, bool async_execution = false);
+  bool addEntryCallback(const std::string& st_name, EntryCallback cb, bool discard_response = false);
 
   /**
    * @brief adds a callback that gets invoked when a state is exited

--- a/scxml_core/src/state_machine.cpp
+++ b/scxml_core/src/state_machine.cpp
@@ -200,7 +200,6 @@ std::shared_future<Response> StateMachine::EntryCbHandler::operator()(const Acti
   });
   qfuture.waitForFinished();
 
-
   // create promise and future to be forwarded
   promise_res_ = std::make_shared<std::promise<Response>>();
   std::shared_future<Response> future_res(promise_res_->get_future());
@@ -215,9 +214,7 @@ std::shared_future<Response> StateMachine::EntryCbHandler::operator()(const Acti
   else
   {
     // run in qt thread and bind Response to future that gets forwarded to client code
-    QtConcurrent::run(tpool_, [this, arg]() {
-      promise_res_->set_value( cb_(arg));
-    });
+    QtConcurrent::run(tpool_, [this, arg]() { promise_res_->set_value(cb_(arg)); });
   }
 
   return future_res;

--- a/scxml_core/src/state_machine.cpp
+++ b/scxml_core/src/state_machine.cpp
@@ -44,8 +44,8 @@
 #include <log4cxx/patternlayout.h>
 #include <log4cxx/consoleappender.h>
 
-static const int WAIT_TRANSITION_PERIOD = 1000;                   // ms
-static const int WAIT_QT_EVENTS = WAIT_TRANSITION_PERIOD / 40.0;  // ms
+static const int WAIT_TRANSITION_PERIOD = 200;  // ms
+static const int WAIT_QT_EVENTS = 20;           // ms
 
 log4cxx::LoggerPtr createConsoleLogger(const std::string& logger_name)
 {

--- a/scxml_core/src/state_machine.cpp
+++ b/scxml_core/src/state_machine.cpp
@@ -204,9 +204,9 @@ std::shared_future<Response> StateMachine::EntryCbHandler::operator()(const Acti
   promise_res_ = std::make_shared<std::promise<Response>>();
   std::shared_future<Response> future_res(promise_res_->get_future());
 
-  if (async_execution_)
+  if (discard_response_)
   {
-    // run in qt thread and return unbinded Response
+    // run in qt thread and return unbinded Response future
     QtConcurrent::run(tpool_, [this, arg]() { return cb_(arg); });
     Response res = true;
     promise_res_->set_value(res);
@@ -633,7 +633,7 @@ bool StateMachine::addPreconditionCallback(const std::string& st_name, Precondit
   return true;
 }
 
-bool StateMachine::addEntryCallback(const std::string& st_name, EntryCallback cb, bool async_execution)
+bool StateMachine::addEntryCallback(const std::string& st_name, EntryCallback cb, bool discard_response)
 {
   if (!hasState(st_name))
   {
@@ -646,7 +646,7 @@ bool StateMachine::addEntryCallback(const std::string& st_name, EntryCallback cb
     LOG4CXX_WARN(logger_, boost::str(boost::format("Entry callback for state %s will be replaced") % st_name));
   }
   entry_callbacks_.insert(
-      std::make_pair(st_name, std::make_shared<EntryCbHandler>(async_thread_pool_, cb, async_execution)));
+      std::make_pair(st_name, std::make_shared<EntryCbHandler>(async_thread_pool_, cb, discard_response)));
 
   return true;
 }

--- a/scxml_core/src/state_machine.cpp
+++ b/scxml_core/src/state_machine.cpp
@@ -214,7 +214,16 @@ std::shared_future<Response> StateMachine::EntryCbHandler::operator()(const Acti
   else
   {
     // run in qt thread and bind Response to future that gets forwarded to client code
-    QtConcurrent::run(tpool_, [this, arg]() { promise_res_->set_value(cb_(arg)); });
+    QtConcurrent::run(tpool_, [this, arg]() {
+      try
+      {
+        promise_res_->set_value(cb_(arg));
+      }
+      catch (std::future_error& e)
+      {
+        // Promise in entry callback already satisfied, no action needed
+      }
+    });
   }
 
   return future_res;

--- a/scxml_core/src/state_machine.cpp
+++ b/scxml_core/src/state_machine.cpp
@@ -38,6 +38,7 @@
 #include <QString>
 #include <QTime>
 #include <QEventLoop>
+#include <chrono>
 #include <boost/format.hpp>
 #include <log4cxx/basicconfigurator.h>
 #include <log4cxx/patternlayout.h>
@@ -54,7 +55,7 @@ log4cxx::LoggerPtr createConsoleLogger(const std::string& logger_name)
   ConsoleAppenderPtr console_appender(new ConsoleAppender(pattern_layout));
   log4cxx::LoggerPtr logger(Logger::getLogger(logger_name));
   logger->addAppender(console_appender);
-  logger->setLevel(Level::getInfo());
+  logger->setLevel(Level::getDebug());
   return logger;
 }
 
@@ -190,6 +191,7 @@ StateMachine::StateMachine(double event_loop_period, log4cxx::LoggerPtr logger)
   , sm_info_(nullptr)
   , event_loop_period_(event_loop_period)
   , async_thread_pool_(new QThreadPool(this))
+  , async_processing_pool_(new QThreadPool(this))
   , logger_(logger ? logger : DEFAULT_LOGGER)
 {
 }
@@ -281,20 +283,40 @@ bool StateMachine::stop()
   return true;
 }
 
-Response StateMachine::execute(const Action& action, bool force)
+std::shared_future<Response> StateMachine::execute(const Action& action, bool force)
 {
+/*  std::packaged_task<Response (Action)> exec_task([this](Action action){
+    return executeAction(action);
+  });*/
+  //std::shared_future<Response> res_fut(exec_task.get_future());
+  //std::shared_future<Response> res_fut;
+
   if (force)
   {
     LOG4CXX_WARN(logger_, "Forcing action " << action.id);
+    // running asynchronously
+    //std::thread(std::move(exec_task), action).detach();
+/*
+    res_fut = std::shared_future<Response>(std::async(std::launch::async, [this, action]()-> Response {
+      return executeAction(action); }));*/
     return executeAction(action);
   }
 
   if (busy_executing_action_ || busy_consuming_entry_cb_)
   {
+    std::promise<Response> res_promise;
+    std::shared_future<Response> res_fut = std::shared_future<Response>(res_promise.get_future());
+
     Response res = Response(false, boost::any(), "SM is busy");
+    res_promise.set_value(res);
     LOG4CXX_DEBUG(logger_, res.msg);
-    return res;
+    return res_fut;
   }
+
+  // running asynchronously
+  //std::thread(std::move(exec_task), action).detach();
+/*  res_fut = std::shared_future<Response>(std::async(std::launch::async, [this, action]()-> Response {
+    return executeAction(action); }));*/
   return executeAction(action);
 }
 
@@ -341,10 +363,10 @@ void StateMachine::processQueuedActions()
     return;
   }
 
-  if (emitStateEnteredSignal())
+/*  if (emitStateEnteredSignal())
   {
     return;  // allow for listeners to handle signal
-  }
+  }*/
 
   Action action;
   {
@@ -357,18 +379,23 @@ void StateMachine::processQueuedActions()
     action = action_queue_.front();
     action_queue_.pop_front();
   }
-  Response res = executeAction(action);
-
+  std::shared_future<Response> res_fut = executeAction(action);
+  //std::thread(&StateMachine::executeAction, this, action).detach();
+/*  QFuture<Response> future = QtConcurrent::run(async_processing_pool_,
+                                               [this, action]() {
+    return executeAction(action); });*/
   return;
 }
 
-Response StateMachine::executeAction(const Action& action)
+std::shared_future<Response> StateMachine::executeAction(const Action& action)
 {
   std::lock_guard<std::mutex> lock(consuming_action_mutex_);
 
   ScopeExit scope_exit(&this->busy_executing_action_);  // sets the flag to busy
 
   Response res;
+  std::promise<Response> res_promise;
+  std::future<Response> res_fut(res_promise.get_future());
 
   // get transitions and check their events
   std::vector<int> transition_ids = getValidTransitionIDs();
@@ -390,7 +417,9 @@ Response StateMachine::executeAction(const Action& action)
     res.msg = boost::str(boost::format("Action '%s' is not valid for any of the active states") % action.id);
     res.success = false;
     LOG4CXX_ERROR(logger_, res.msg);
-    return std::move(res);
+
+    res_promise.set_value(res);
+    return res_fut;
   }
 
   int current_src_st_id = sm_info_->transitionSource(transition_ids.front());
@@ -411,7 +440,8 @@ Response StateMachine::executeAction(const Action& action)
     res.msg = boost::str(boost::format("No valid target states were found for transition %1% -> %2%") %
                          current_src_st_name % action.id);
     res.success = false;
-    return std::move(res);
+    res_promise.set_value(res);
+    return res_fut;
   }
 
   // checking precondition
@@ -430,33 +460,41 @@ Response StateMachine::executeAction(const Action& action)
       }))
   {
     LOG4CXX_ERROR(logger_, res.msg);
-    return std::move(res);  // precondition failed, not proceeding with transition
+    res_promise.set_value(res); // precondition failed, not proceeding with transition
+    return res_fut;
   }
 
-  // setting up synchronization variables
+  // setting up synchronization variables*
   std::promise<Action> action_promise;
   action_future_ = std::shared_future<Action>(action_promise.get_future());
   action_promise.set_value(action);
-  response_promise_ = std::promise<Response>();
-  std::shared_future<Response> response_future = std::shared_future<Response>(response_promise_.get_future());
+  response_transition_ = std::promise<ResponseFuturesMap>();
+  std::shared_future<ResponseFuturesMap> response_future = std::shared_future<ResponseFuturesMap>(
+      response_transition_.get_future());
 
   // submitting event, entry callbacks registered in signalSetup() should be invoked
+  std::chrono::steady_clock::time_point start =  std::chrono::steady_clock::now();
   LOG4CXX_DEBUG(logger_, "Submitting event with id: " << action.id);
   sm_->submitEvent(QString::fromStdString(action.id));
+  std::chrono::steady_clock::time_point end =  std::chrono::steady_clock::now();
+  LOG4CXX_DEBUG(logger_, "Done submitting event, took  " <<
+                std::chrono::duration_cast<std::chrono::seconds>(end - start).count() <<" seconds");
 
   // wait until transition is complete
   QTime stop_time = QTime::currentTime().addMSecs(WAIT_TRANSITION_PERIOD);
   bool transition_made = false;
   QVector<QScxmlStateMachineInfo::StateId> current_st_ids;
   while (QTime::currentTime() < stop_time && !transition_made)
+  //while (!transition_made)
   {
     QCoreApplication::processEvents(QEventLoop::AllEvents, WAIT_QT_EVENTS);
+    //LOG4CXX_DEBUG(logger_, "Waiting on future to make transition ");
     transition_made = response_future.wait_for(std::chrono::milliseconds(WAIT_QT_EVENTS)) == std::future_status::ready;
   }
 
   // resetting synchronization variables
-  action_future_ = std::shared_future<Action>();
-  response_promise_ = std::promise<Response>();
+  //action_future_ = std::shared_future<Action>();
+  response_transition_ = std::promise<ResponseFuturesMap>();
   if (!transition_made)
   {
     QVector<QScxmlStateMachineInfo::StateId> current_st_ids = sm_info_->configuration();
@@ -477,14 +515,109 @@ Response StateMachine::executeAction(const Action& action)
     res.success = false;
     LOG4CXX_ERROR(logger_, res.msg);
     LOG4CXX_ERROR(logger_, "Current states are: " << current_states_str.c_str());
-    return std::move(res);
+    res_promise.set_value(res);
+    return res_fut;
   }
-  LOG4CXX_DEBUG(logger_, "State transitions completed");
 
   // retrieve response now
-  res = response_future.get();
+  ResponseFuturesMap futures_map = response_future.get();
+  for(auto& kv : futures_map)
+  {
+    int state_id = kv.first;
+    QFuture<Response>& future = kv.second;
+/*    while (!future.isFinished())
+    {
+      QCoreApplication::processEvents(QEventLoop::AllEvents, WAIT_QT_EVENTS);
+    }*/
+
+    if(sm_private_->m_stateTable->state(state_id).isAtomic())
+    {
+      res_fut = std::async(std::launch::async, [future](){
+        return future.result();
+      });
+    }
+    const std::string& st_name = sm_info_->stateName(state_id).toStdString();
+    LOG4CXX_DEBUG(logger_, "Finished executing entry callback for state "<<st_name);
+  }
+
+  if(futures_map.empty())
+  {
+    res.success = true;
+    res_promise.set_value(res);
+  }
+
   LOG4CXX_DEBUG(logger_, "Retrieved response structure from future");
-  return std::move(res);
+  return res_fut;
+}
+
+void StateMachine::signalSetup()
+{
+  connect(sm_info_, &SMInfo::statesEntered, [this](const QVector<QScxmlStateMachineInfo::StateId>& states) {
+
+    LOG4CXX_DEBUG(logger_, "Entered  statesEntered callback");
+    ScopeExit scope_exit(&this->busy_consuming_entry_cb_);  // sets the flag to busy
+
+    std::lock_guard<std::mutex> lock(entered_states_mutex_);
+    entered_states_queue_.clear();
+    for (const QScxmlStateMachineInfo::StateId& id : states)
+    {
+      entered_states_queue_.push_back(id);  // will emit entered signals from the processing thread
+    }
+
+    Action action;
+    if(action_future_.valid())
+    {
+      action  = action_future_.get();
+    }
+
+
+    bool atomic_found = false;
+    ResponseFuturesMap futures_map;
+    for (int id : states)
+    {
+      QFuture<Response> temp_res_future;
+      const std::string& st_name = sm_info_->stateName(id).toStdString();
+      if (entry_callbacks_.count(st_name) > 0)
+      {
+        temp_res_future = (*entry_callbacks_.at(st_name))(action);
+        futures_map.insert(std::make_pair(id, temp_res_future));
+      }
+/*      else
+      {
+        continue;
+      }*/
+
+/*
+      if (!atomic_found)
+      {
+        res = temp_res;
+      }
+*/
+
+      //atomic_found = sm_private_->m_stateTable->state(id).isAtomic();
+    }
+    //LOG4CXX_DEBUG(logger_, "State transitions completed");
+    response_transition_.set_value(futures_map);
+    LOG4CXX_DEBUG(logger_, "All entered states processed");
+  });
+
+  connect(sm_info_, &SMInfo::statesExited, [this](const QVector<QScxmlStateMachineInfo::StateId>& states) {
+    // invoke exit callbacks
+    std::for_each(states.begin(), states.end(), [this](const QScxmlStateMachineInfo::StateId& id) {
+      std::string st_name = sm_info_->stateName(id).toStdString();
+      if (exit_callbacks_.count(st_name) > 0)
+      {
+        LOG4CXX_DEBUG(logger_, "Started exit callback for state "<< st_name);
+        exit_callbacks_.at(st_name)();
+        LOG4CXX_DEBUG(logger_, "Finished exit callback for state "<< st_name);
+      }
+    });
+
+    for (const QScxmlStateMachineInfo::StateId& id : states)
+    {
+      emit this->state_exited(getStateFullName(sm_info_, id));
+    }
+  });
 }
 
 bool StateMachine::addPreconditionCallback(const std::string& st_name, PreconditionCallback cb)
@@ -658,75 +791,6 @@ bool StateMachine::emitStateEnteredSignal()
     QTimer::singleShot(10, [&, state_name]() { emit this->state_entered(state_name); });
   }
   return emitted;
-}
-
-void StateMachine::signalSetup()
-{
-  connect(sm_info_, &SMInfo::statesEntered, [this](const QVector<QScxmlStateMachineInfo::StateId>& states) {
-    ScopeExit scope_exit(&this->busy_consuming_entry_cb_);  // sets the flag to busy
-
-    std::lock_guard<std::mutex> lock(entered_states_mutex_);
-    entered_states_queue_.clear();
-    for (const QScxmlStateMachineInfo::StateId& id : states)
-    {
-      entered_states_queue_.push_back(id);  // will emit entered signals from the processing thread
-    }
-
-    // getting action set in executionAction()
-    Action action;
-    if (action_future_.valid())
-    {
-      action = action_future_.get();
-      LOG4CXX_DEBUG(logger_, "Got Action object from future");
-    }
-    else
-    {
-      LOG4CXX_DEBUG(logger_, "No action available in future");
-    }
-
-    // calling entry callbacks
-    Response res = true;  // response returned through the std::future
-    bool atomic_found = false;
-    for (int id : states)
-    {
-      Response temp_res;
-      const std::string& st_name = sm_info_->stateName(id).toStdString();
-      if (entry_callbacks_.count(st_name) > 0)
-      {
-        temp_res = (*entry_callbacks_.at(st_name))(action);
-      }
-      else
-      {
-        continue;
-      }
-
-      if (!atomic_found)
-      {
-        res = temp_res;
-      }
-
-      atomic_found = sm_private_->m_stateTable->state(id).isAtomic();
-    }
-
-    response_promise_.set_value(res);
-    LOG4CXX_DEBUG(logger_, "All entered states processed");
-  });
-
-  connect(sm_info_, &SMInfo::statesExited, [this](const QVector<QScxmlStateMachineInfo::StateId>& states) {
-    // invoke exit callbacks
-    std::for_each(states.begin(), states.end(), [this](const QScxmlStateMachineInfo::StateId& id) {
-      std::string st_name = sm_info_->stateName(id).toStdString();
-      if (exit_callbacks_.count(st_name) > 0)
-      {
-        exit_callbacks_.at(st_name)();
-      }
-    });
-
-    for (const QScxmlStateMachineInfo::StateId& id : states)
-    {
-      emit this->state_exited(getStateFullName(sm_info_, id));
-    }
-  });
 }
 
 std::vector<int> StateMachine::getTransitionsIDs(const QVector<int>& states) const


### PR DESCRIPTION
**!!!!!!!!WARNING**, minor API change 

The changes in this PR allow the client code to have more control over the handling of the response data structures returned by the state entry callbacks.  Returning a std::shared_future allows the calling application to wait for the completion of a task when the result is needed.
