### PR TITLE
Feature custom future class

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@ The QScxml library is only available from version Qt 5.7 and higher. This implem
     sudo add-apt-repository ppa:beineri/opt-qt-5.13.2-bionic
     sudo apt-get update
     ```
-    > Note: Edit command below to match the version of qt that you'd like to install
+    > Note: Edit command above to match the version of qt that you'd like to install
 - Install the full Qt library 
     ```
     sudo apt install qt513-meta-full
     ```
+    > Note: Edit command above to match the version of qt that you'd like to install
+
 #### Alternative Download (Qt Installer)
 - The library can be downloaded from [here](http://download.qt.io/official_releases/qt/).  Run the installation script with root access and follow the on screen instructions.
   
@@ -211,7 +213,7 @@ export LD_LIBRARY_PATH=<path>/<to>/<qt>/plugins:$LD_LIBRARY_PATH
     This means that the actions available at the current state are **trAborted** and **userClear**
 7. Publish an action from the list to the state machine, for instance the **userClear** action will be requested as follows:
     ```
-    rostopic pub -1 /execute_state std_msgs/String "data: 'userClear'"
+    rostopic pub -1 /execute_action std_msgs/String "data: 'userClear'"
     ```
 
     This should cause the state machine to go into the **st2Clearing** state.  A few seconds after that it should go into the **st2Stopped** state as the custom entry callback function automatically posts an action.

--- a/rclcpp_scxml_demos/src/demo_scxml_sm.cpp
+++ b/rclcpp_scxml_demos/src/demo_scxml_sm.cpp
@@ -72,7 +72,7 @@ public:
 
           rclcpp::Clock ros_clock;
           TransitionResult result = sm_->execute(Action{ .id = msg->data, .data = ros_clock.now().seconds() });
-          if(!result)
+          if (!result)
           {
             RCLCPP_INFO(node_->get_logger(), result.getErrorMessage());
             return;
@@ -81,14 +81,14 @@ public:
           RCLCPP_INFO(node_->get_logger(), "Action %s successfully executed, Transition succeeded", msg->data.c_str());
 
           // check if response futures are available
-          if(!result.hasPendingResponse())
+          if (!result.hasPendingResponse())
           {
             return;
           }
 
           ResponseFuture res_fut = result.getResponse();
-          RCLCPP_INFO(node_->get_logger(), "Waiting for states's \"%s\" callback response now",
-                      res_fut.getState().c_str() );
+          RCLCPP_INFO(
+              node_->get_logger(), "Waiting for states's \"%s\" callback response now", res_fut.getState().c_str());
           if (res_fut.wait_for(std::chrono::seconds(5)) != std::future_status::ready)
           {
             RCLCPP_INFO(node_->get_logger(), "Took too long to get response");

--- a/roscpp_scxml_demos/src/demo_scxml_sm.cpp
+++ b/roscpp_scxml_demos/src/demo_scxml_sm.cpp
@@ -75,7 +75,7 @@ public:
           }
 
           TransitionResult result = sm_->execute(Action{ .id = msg->data, .data = ros::Time::now().toSec() });
-          if(!result)
+          if (!result)
           {
             ROS_INFO_STREAM(result.getErrorMessage());
             return;
@@ -83,7 +83,7 @@ public:
           ROS_INFO("Action %s successfully executed, Transition succeeded", msg->data.c_str());
 
           // check if response futures are available
-          if(!result.hasPendingResponse())
+          if (!result.hasPendingResponse())
           {
             return;
           }

--- a/scxml_core/include/scxml_core/state_machine.h
+++ b/scxml_core/include/scxml_core/state_machine.h
@@ -112,48 +112,40 @@ class StateMachine;
  * @brief A shared future with additional information regarding the Response object
  *        return by entry callbacks associated with states
  */
-class ResponseFuture: public std::shared_future<Response>
+class ResponseFuture : public std::shared_future<Response>
 {
 public:
-
   /**
    * True if the future is not linked to the response produced by the state's entry callback
    * @return a boolean
    */
-  bool isDetached() const
-  {
-    return is_detached_;
-  }
+  bool isDetached() const { return is_detached_; }
 
   /**
    * @brief the name of the state that generated the response by invoking its entry callback
    * @return a string
    */
-  std::string getState() const
-  {
-    return state_name_;
-  }
+  std::string getState() const { return state_name_; }
 
   /**
    * @brief true if the state that produced the response is atomic
    * @return a boolean
    */
-  bool isAtomic() const
-  {
-    return is_atomic_;
-  }
+  bool isAtomic() const { return is_atomic_; }
 
-  ~ResponseFuture(){}
+  ~ResponseFuture() {}
 
 private:
   friend class StateMachine;
 
-  ResponseFuture(const std::shared_future<Response>& res_fut,bool is_detached, const std::string& state_name, bool is_atomic);
+  ResponseFuture(const std::shared_future<Response>& res_fut,
+                 bool is_detached,
+                 const std::string& state_name,
+                 bool is_atomic);
 
   bool is_detached_;
   bool is_atomic_;
   std::string state_name_;
-
 };
 
 /**
@@ -163,7 +155,6 @@ private:
 class TransitionResult
 {
 public:
-
   /**
    * @brief Evaluates to true when the transition succeeded, false otherwise
    */
@@ -174,7 +165,7 @@ public:
    *        made active by this transition.  The front element corresponds to the atomic state's response
    * @return a vector of ResponseFutures
    */
-  const std::vector<ResponseFuture>& getResponses() const {return responses_;}
+  const std::vector<ResponseFuture>& getResponses() const { return responses_; }
 
   /**
    * @brief Returns the response produced by the callback associated with the atomic state
@@ -195,17 +186,16 @@ public:
    * @brief the error message providing a brief description of the error that prevented the transition.
    * @return a string
    */
-  const std::string getErrorMessage() const {return err_msg_;}
+  const std::string getErrorMessage() const { return err_msg_; }
 
 private:
   friend class StateMachine;
 
-  TransitionResult(bool succeeded, const std::vector<ResponseFuture>& responses, const std::string err_msg ="");
+  TransitionResult(bool succeeded, const std::vector<ResponseFuture>& responses, const std::string err_msg = "");
 
   bool succeeded_;
   std::vector<ResponseFuture> responses_;
   std::string err_msg_;
-
 };
 
 class StateMachine : public QObject


### PR DESCRIPTION
Creates custom future class that inherits from `std::shared_future` which allows the user to query information about the status of the response before attempting to get it through the known `std::shared_future` methods