### PR TITLE
Feature/clang warnings

### DIFF
--- a/scxml_core/include/scxml_core/state_machine.h
+++ b/scxml_core/include/scxml_core/state_machine.h
@@ -56,6 +56,8 @@ namespace scxml_core
 {
 struct Action
 {
+  Action() = default;
+  Action(std::string id, boost::any data = boost::any()) : id(id), data(data){};
   std::string id;  /**@brief name of the event */
   boost::any data; /**@brief optional data needed by the state */
 

--- a/scxml_core/include/scxml_core/state_machine.h
+++ b/scxml_core/include/scxml_core/state_machine.h
@@ -182,13 +182,13 @@ public:
    *        on the ResponseFuture
    * @return  a boolean
    */
-  const bool hasPendingResponse() const;
+  bool hasPendingResponse() const;
 
   /**
    * @brief the error message providing a brief description of the error that prevented the transition.
    * @return a string
    */
-  const std::string getErrorMessage() const { return err_msg_; }
+  std::string getErrorMessage() const { return err_msg_; }
 
 private:
   friend class StateMachine;
@@ -211,7 +211,7 @@ private:
   {
   public:
     EntryCbHandler(QThreadPool* thread_pool, EntryCallback cb, bool discard_response = false)
-      : cb_(cb), discard_response_(discard_response), tpool_(thread_pool)
+      : discard_response_(discard_response), cb_(cb), tpool_(thread_pool)
     {
     }
 


### PR DESCRIPTION
Builds on #14. This cleans up a bunch of Clang warnings. The most controversial of which will probably be the removal of std::moves on local variables. Clang gives the warning that std::move on local variables prevents copy ellision. The rest are just initializer lists in the wrong order and return by value types marked const.