### PR TITLE
changed CMake Module path to prefix path in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ The QScxml library is only available from version Qt 5.7 and higher. This implem
 In order to make this library accessible to cmake the `CMAKE_MODULE_PATH` and `LD_LIBRARY_PATH` environment variables must be set.  Locate your Qt installation directory (usually in the */opt* directory) and set the environment variables as follows:
 
 ```bash
-export CMAKE_MODULE_PATH=<path>/<to>/<qt>/lib/cmake:$CMAKE_MODULE_PATH
+export CMAKE_PREFIX_PATH=<path>/<to>/<qt>/lib/cmake:$CMAKE_PREFIX_PATH
 export LD_LIBRARY_PATH=<path>/<to>/<qt>/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=<path>/<to>/<qt>/plugins:$LD_LIBRARY_PATH  
 ```
 
 For the version installed above qt513 it would be as follows:
 ```bash
-export CMAKE_MODULE_PATH=/opt/qt513/lib/cmake:$CMAKE_MODULE_PATH
+export CMAKE_PREFIX_PATH=/opt/qt513/lib/cmake:$CMAKE_PREFIX_PATH
 export LD_LIBRARY_PATH=/opt/qt513/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=/opt/qt513/plugins:$LD_LIBRARY_PATH
 ```


### PR DESCRIPTION
I'm not sure if this is correct for every case, but in my case I had to make this change in order to compile.