### PR TITLE
Allow states to have multiple precondition callbacks

### DIFF
--- a/scxml_core/include/scxml_core/state_machine.h
+++ b/scxml_core/include/scxml_core/state_machine.h
@@ -341,7 +341,7 @@ protected:
   std::shared_future<Action> action_future_;
   using ResponseFuturesMap = std::map<int, std::shared_future<Response>>;
   std::promise<ResponseFuturesMap> responses_map_promise_;
-  std::map<std::string, PreconditionCallback> precond_callbacks_;
+  std::map<std::string, std::vector<PreconditionCallback>> precond_callbacks_;
   std::map<std::string, EntryCbHandlerPtr> entry_callbacks_;
   std::map<std::string, std::function<void()>> exit_callbacks_;
   QThreadPool* async_thread_pool_;

--- a/scxml_core/src/state_machine.cpp
+++ b/scxml_core/src/state_machine.cpp
@@ -478,11 +478,14 @@ TransitionResult StateMachine::executeAction(const Action& action)
         for (auto cb : precond_callbacks_[st])
         {
           precond_res = cb(action);
+          if (!precond_res)
+          {
+            // break on the first failed precondition
+            precond_res.msg = boost::str(boost::format("Precondition for state %s failed: %s") % st % precond_res.msg);
+            break;
+          }
         }
-        if (!precond_res)
-        {
-          precond_res.msg = boost::str(boost::format("Precondition for state %s failed: %s") % st % precond_res.msg);
-        }
+
         return TransitionResult(precond_res.success, {}, precond_res.msg);
       }))
   {

--- a/scxml_core/src/state_machine.cpp
+++ b/scxml_core/src/state_machine.cpp
@@ -638,9 +638,13 @@ bool StateMachine::addPreconditionCallback(const std::string& st_name, Precondit
 
   auto pc = precond_callbacks_.find(st_name);
   if (pc == precond_callbacks_.end())
+  {
     precond_callbacks_.insert(std::make_pair(st_name, std::vector<PreconditionCallback>({cb})));
+  }
   else
+  {
     pc->second.push_back(cb);
+  }
 
   return true;
 }

--- a/scxml_core/src/state_machine.cpp
+++ b/scxml_core/src/state_machine.cpp
@@ -475,13 +475,13 @@ TransitionResult StateMachine::executeAction(const Action& action)
         {
           return true;  // no precondition
         }
-        for (auto cb : precond_callbacks_[st])
+        for (std::size_t i = 0; i < precond_callbacks_[st].size(); i++)
         {
-          precond_res = cb(action);
+          precond_res = precond_callbacks_[st][i](action);
           if (!precond_res)
           {
             // break on the first failed precondition
-            precond_res.msg = boost::str(boost::format("Precondition for state %s failed: %s") % st % precond_res.msg);
+            precond_res.msg = boost::str(boost::format("Precondition %i for state %s failed: %s") % i % st % precond_res.msg);
             break;
           }
         }

--- a/scxml_core/src/state_machine.cpp
+++ b/scxml_core/src/state_machine.cpp
@@ -481,7 +481,8 @@ TransitionResult StateMachine::executeAction(const Action& action)
           if (!precond_res)
           {
             // break on the first failed precondition
-            precond_res.msg = boost::str(boost::format("Precondition %i for state %s failed: %s") % i % st % precond_res.msg);
+            precond_res.msg =
+                boost::str(boost::format("Precondition %i for state %s failed: %s") % i % st % precond_res.msg);
             break;
           }
         }

--- a/scxml_core/src/state_machine.cpp
+++ b/scxml_core/src/state_machine.cpp
@@ -639,7 +639,7 @@ bool StateMachine::addPreconditionCallback(const std::string& st_name, Precondit
   auto pc = precond_callbacks_.find(st_name);
   if (pc == precond_callbacks_.end())
   {
-    precond_callbacks_.insert(std::make_pair(st_name, std::vector<PreconditionCallback>({cb})));
+    precond_callbacks_.insert(std::make_pair(st_name, std::vector<PreconditionCallback>({ cb })));
   }
   else
   {


### PR DESCRIPTION
- Modify storage of state precondition callbacks so each state name maps to a vector templated to the type `PreconditionCallback`.
- When evaluating a state's precondition callbacks, iterate through each callback in the vector and evaluate it.
- If one of the state's precondition callbacks returns a failure state, get the contents of its result message and stop evaluating precondition callbacks for that state.

This would be more challenging to do for entry callbacks, since those need more work to keep track of the response futures.