### PR TITLE
Add "recursive" neighbor search

### DIFF
--- a/include/scxml_core/scxml_sm_interface.h
+++ b/include/scxml_core/scxml_sm_interface.h
@@ -24,12 +24,13 @@ class ScxmlSMInterface
 public:
   ScxmlSMInterface(const std::string& scxml_file);
   /**
-   * @brief Returns the state to which a desired transition leads
+   * @brief Returns the state to which a desired transition leads, from the input state
    */
   QString getNeighbor(const QString& state, const QString& transition);
 
   /**
-   * @brief Returns the state to which a desired transition leads, including states owned by higher-level active states
+   * @brief Returns the state to which a desired transition leads, from the current state (including any active
+   * higher-level parent states)
    */
   QString getActiveStateNeighbor(const QString& transition);
 
@@ -66,9 +67,6 @@ protected:
   QScxmlStateMachine* sm_;
   const StateTransitionMap state_transition_map_;
   std::map<QString, QFuture<void>> future_map_;
-
-private:
-  QString find_text(const QString& state, const QString& search_text);
 };
 
 }  // namespace scxml_core

--- a/include/scxml_core/scxml_sm_interface.h
+++ b/include/scxml_core/scxml_sm_interface.h
@@ -25,9 +25,10 @@ public:
   ScxmlSMInterface(const std::string& scxml_file);
   /**
    * @brief Returns the state to which a desired transition leads
-   * @param recursive - checks parent states for the desired transition
    */
-  QString getNeighbor(const QString& state, const QString& transition, const bool recursive = false);
+  QString getNeighbor(const QString& state, const QString& transition);
+
+  QString getActiveStateNeighbor(const QString& transition);
 
   /**
    * @brief Adds a callback to the input state that will be invoked on entry to the state

--- a/include/scxml_core/scxml_sm_interface.h
+++ b/include/scxml_core/scxml_sm_interface.h
@@ -25,8 +25,9 @@ public:
   ScxmlSMInterface(const std::string& scxml_file);
   /**
    * @brief Returns the state to which a desired transition leads
+   * @param recursive - checks parent states for the desired transition
    */
-  QString getNeighbor(const QString& state, const QString& transition);
+  QString getNeighbor(const QString& state, const QString& transition, const bool recursive = false);
 
   /**
    * @brief Adds a callback to the input state that will be invoked on entry to the state
@@ -61,6 +62,9 @@ protected:
   QScxmlStateMachine* sm_;
   const StateTransitionMap state_transition_map_;
   std::map<QString, QFuture<void>> future_map_;
+
+private:
+  QString find_text(const QString& state, const QString& search_text);
 };
 
 }  // namespace scxml_core

--- a/include/scxml_core/scxml_sm_interface.h
+++ b/include/scxml_core/scxml_sm_interface.h
@@ -28,6 +28,9 @@ public:
    */
   QString getNeighbor(const QString& state, const QString& transition);
 
+  /**
+   * @brief Returns the state to which a desired transition leads, including states owned by higher-level active states
+   */
   QString getActiveStateNeighbor(const QString& transition);
 
   /**

--- a/src/scxml_sm_interface.cpp
+++ b/src/scxml_sm_interface.cpp
@@ -150,14 +150,38 @@ ScxmlSMInterface::ScxmlSMInterface(const std::string& scxml_file)
   }
 }
 
-// use this to determine the next state in the state machine, given the name of the transition you'd like to query
-QString ScxmlSMInterface::getNeighbor(const QString& state, const QString& search_text)
+QString ScxmlSMInterface::find_text(const QString& state, const QString& search_text)
 {
   for (auto& pair : state_transition_map_.at(state))
   {
     if (pair.first == search_text)
     {
       return pair.second;
+    }
+  }
+  throw std::runtime_error("State '" + state.toStdString() + "' does not have a neighbor after transition '" +
+                           search_text.toStdString() + "'");
+}
+
+// use this to determine the next state in the state machine, given the name of the transition you'd like to query
+QString ScxmlSMInterface::getNeighbor(const QString& state, const QString& search_text, const bool recursive)
+{
+  QString answer;
+  try
+  {
+    return find_text(state, search_text);
+  }
+  catch (std::runtime_error)
+  {
+    if (recursive)
+    {
+      QStringList active_states = sm_->activeStateNames(false);
+      for (int i = 0; i < active_states.size(); i++)
+        // Next state
+        if ((not QString::compare(active_states.at(i), state)) && (not QString::compare(active_states.at(i), "Master")))
+        {
+          return find_text(state, search_text);
+        }
     }
   }
   throw std::runtime_error("State '" + state.toStdString() + "' does not have a neighbor after transition '" +

--- a/src/scxml_sm_interface.cpp
+++ b/src/scxml_sm_interface.cpp
@@ -163,7 +163,6 @@ QString ScxmlSMInterface::getNeighbor(const QString& state, const QString& trans
                            transition.toStdString() + "'");
 }
 
-// use this to determine the next state in the state machine, given the name of the transition you'd like to query
 QString ScxmlSMInterface::getActiveStateNeighbor(const QString& transition)
 {
   for (const QString& state : sm_->activeStateNames(false))

--- a/src/scxml_sm_interface.cpp
+++ b/src/scxml_sm_interface.cpp
@@ -150,42 +150,34 @@ ScxmlSMInterface::ScxmlSMInterface(const std::string& scxml_file)
   }
 }
 
-QString ScxmlSMInterface::find_text(const QString& state, const QString& search_text)
+QString ScxmlSMInterface::getNeighbor(const QString& state, const QString& transition)
 {
   for (auto& pair : state_transition_map_.at(state))
   {
-    if (pair.first == search_text)
+    if (pair.first == transition)
     {
       return pair.second;
     }
   }
   throw std::runtime_error("State '" + state.toStdString() + "' does not have a neighbor after transition '" +
-                           search_text.toStdString() + "'");
+                           transition.toStdString() + "'");
 }
 
 // use this to determine the next state in the state machine, given the name of the transition you'd like to query
-QString ScxmlSMInterface::getNeighbor(const QString& state, const QString& search_text, const bool recursive)
+QString ScxmlSMInterface::getActiveStateNeighbor(const QString& transition)
 {
-  QString answer;
-  try
+  for (const QString& state : sm_->activeStateNames(false))
   {
-    return find_text(state, search_text);
-  }
-  catch (std::runtime_error)
-  {
-    if (recursive)
+    try
     {
-      QStringList active_states = sm_->activeStateNames(false);
-      for (int i = 0; i < active_states.size(); i++)
-        // Next state
-        if ((not QString::compare(active_states.at(i), state)) && (not QString::compare(active_states.at(i), "Master")))
-        {
-          return find_text(state, search_text);
-        }
+      return getNeighbor(state, transition);
+    }
+    catch (const std::exception&)
+    {
     }
   }
-  throw std::runtime_error("State '" + state.toStdString() + "' does not have a neighbor after transition '" +
-                           search_text.toStdString() + "'");
+  throw std::runtime_error("Active state & parents do not have a neighbor after transition '" +
+                           transition.toStdString() + "'");
 }
 
 void ScxmlSMInterface::addOnEntryCallback(const QString& state, const std::function<void()>& callback, bool async)


### PR DESCRIPTION
This PR adds a function to search the current state and its active parent states (i.e., recursion) for the state to which a given transition leads